### PR TITLE
feat: 시청방 목록 무한 스크롤 구현 및 시청방 버그 수정

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -30,12 +30,12 @@ export function Dashboard({ onPageChange, onPlaylistOpen, onContentPlay, onJoinR
   // ========== API INTEGRATION POINT - START ==========
   const fetchLiveRooms = async () => {
     try {
-      const data = await watchRoomService.getWatchRooms({ limit: 9 })
-      // 배열인지 확인 후 설정
-      if (Array.isArray(data)) {
-        setLiveRooms(data)
+      const response = await watchRoomService.getWatchRooms({ size: 9 })
+      // CursorPageResponseDto에서 실제 데이터 배열 추출
+      if (Array.isArray(response.data)) {
+        setLiveRooms(response.data)
       } else {
-        console.error('Live rooms data is not an array:', data)
+        console.error('Live rooms data is not an array:', response.data)
         setLiveRooms([])
       }
     } catch (error) {

--- a/src/components/LiveRooms.tsx
+++ b/src/components/LiveRooms.tsx
@@ -21,12 +21,20 @@ export function LiveRooms({ onJoinRoom, onCreateRoom, currentUserId }: LiveRooms
   const [refreshing, setRefreshing] = useState(false)
   // 추가: 참여 중인 방 id 상태
   const [joiningRoomId, setJoiningRoomId] = useState<string | null>(null)
+  const [direction, setDirection] = useState<'asc' | 'desc'>('desc')
+  const [cursor, setCursor] = useState<string | null>(null)
+  const [hasNext, setHasNext] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [totalElements, setTotalElements] = useState(0)
 
-  // 시청방 목록 로드
-  const loadRooms = async (showLoading = true) => {
+  // 시청방 목록 로드 (초기 로드 또는 무한 스크롤)
+  const loadRooms = async (isInitialLoad = true, isLoadMore = false) => {
     try {
-      if (showLoading) {
+      if (isInitialLoad) {
         setLoading(true)
+        setCursor(null)
+      } else if (isLoadMore) {
+        setLoadingMore(true)
       } else {
         setRefreshing(true)
       }
@@ -34,32 +42,80 @@ export function LiveRooms({ onJoinRoom, onCreateRoom, currentUserId }: LiveRooms
       
       const roomsData = await watchRoomService.getWatchRooms({
         query: searchQuery,
-        sortBy: sortBy === 'participants' ? 'participantCount' : sortBy === 'latest' ? 'createdAt' : 'createdAt'
+        sortBy: sortBy === 'participants' ? 'participantCount' : sortBy === 'latest' ? 'createdAt' : 'createdAt',
+        direction: direction == 'asc'? 'asc' :'desc',
+        cursor: isInitialLoad ? null : cursor,
+        size: 20,
       })
       
-      setRooms(roomsData)
+      // 초기 로드나 새로고침이면 데이터 교체, 무한 스크롤이면 데이터 추가
+      if (isInitialLoad || !isLoadMore) {
+        setRooms(roomsData.data)
+      } else {
+        setRooms(prevRooms => [...prevRooms, ...roomsData.data])
+      }
+      
+      // 커서와 페이지네이션 정보 업데이트
+      setCursor(roomsData.nextCursor)
+      setHasNext(roomsData.hasNext)
+      setTotalElements(roomsData.totalElements)
+      
     } catch (error) {
       console.error('시청방 목록 로드 오류:', error)
       setError(error instanceof Error ? error.message : '시청방 목록을 불러오는 중 오류가 발생했습니다.')
     } finally {
       setLoading(false)
       setRefreshing(false)
+      setLoadingMore(false)
     }
   }
 
-  // 검색 및 정렬 변경 시 목록 새로고침
+  // 무한 스크롤을 위한 더 많은 데이터 로드
+  const loadMoreRooms = async () => {
+    if (!hasNext || loadingMore || loading) {
+      return
+    }
+    
+    await loadRooms(false, true)
+  }
+
+  // 검색 및 정렬 변경 시 목록 새로고침 (페이지네이션 초기화)
   useEffect(() => {
     const timeoutId = setTimeout(() => {
-      loadRooms(false)
+      // 검색이나 정렬이 변경되면 첫 페이지부터 다시 시작
+      setCursor(null)
+      setHasNext(true)
+      loadRooms(true, false) // 초기 로드로 처리
     }, 300) // 300ms 디바운스
     
     return () => clearTimeout(timeoutId)
-  }, [searchQuery, sortBy])
+  }, [searchQuery, sortBy, direction])
 
   // 초기 로드
   useEffect(() => {
     loadRooms(true)
   }, [])
+
+  // 무한 스크롤을 위한 스크롤 이벤트 리스너
+  useEffect(() => {
+    const handleScroll = () => {
+      if (loading || loadingMore || !hasNext) {
+        return
+      }
+
+      const scrollTop = window.pageYOffset || document.documentElement.scrollTop
+      const windowHeight = window.innerHeight
+      const documentHeight = document.documentElement.scrollHeight
+
+      // 페이지 하단에서 200px 지점에 도달하면 더 많은 데이터 로드
+      if (scrollTop + windowHeight >= documentHeight - 100) {
+        loadMoreRooms()
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll)
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [loading, loadingMore, hasNext, cursor]) // 의존성 배열에 필요한 상태들 추가
 
 
   // const formatTimeAgo = (dateString: string) => {
@@ -102,7 +158,11 @@ export function LiveRooms({ onJoinRoom, onCreateRoom, currentUserId }: LiveRooms
             <h1 className="text-3xl">라이브 시청방</h1>
             <div className="flex gap-3">
               <Button
-                onClick={() => loadRooms(false)}
+                onClick={() => {
+                  setCursor(null)
+                  setHasNext(true)
+                  loadRooms(false, false)
+                }}
                 disabled={refreshing}
                 variant="outline"
                 className="border-white/20 hover:bg-white/5"
@@ -152,7 +212,12 @@ export function LiveRooms({ onJoinRoom, onCreateRoom, currentUserId }: LiveRooms
 
           {/* Stats */}
           <div className="flex items-center gap-4 text-white/60">
-            <span>현재 {displayRooms.length}개 시청방 활성화</span>
+            <span>
+              {totalElements > 0 
+                ? `${displayRooms.length}개 / 총 ${totalElements}개 시청방`
+                : `현재 ${displayRooms.length}개 시청방 활성화`
+              }
+            </span>
             <div className="px-2 py-1 rounded-full text-xs font-medium bg-[#4ecdc4]/20 text-[#4ecdc4] border border-[#4ecdc4]/30">
               <Users className="w-3 h-3 mr-1 inline" />
               실시간
@@ -165,7 +230,11 @@ export function LiveRooms({ onJoinRoom, onCreateRoom, currentUserId }: LiveRooms
           <div className="mb-8 p-4 bg-red-500/10 border border-red-500/20 rounded-lg">
             <p className="text-red-400 mb-2">{error}</p>
             <Button
-              onClick={() => loadRooms(true)}
+              onClick={() => {
+                setCursor(null)
+                setHasNext(true)
+                loadRooms(true, false)
+              }}
               variant="outline"
               size="sm"
               className="border-red-400/30 text-red-400 hover:bg-red-500/10"
@@ -377,8 +446,34 @@ export function LiveRooms({ onJoinRoom, onCreateRoom, currentUserId }: LiveRooms
               </div>
             ))}
         </div>
-        </div>
         
+        {/* 무한 스크롤 로딩 및 더보기 버튼 */}
+        {displayRooms.length > 0 && (
+          <div className="text-center py-6">
+            {loadingMore && (
+              <div className="flex items-center justify-center mb-4">
+                <Loader2 className="w-6 h-6 animate-spin text-[#4ecdc4] mr-2" />
+                <span className="text-white/60">더 많은 시청방을 불러오는 중...</span>
+              </div>
+            )}
+            
+            {!loadingMore && hasNext && (
+              <Button
+                onClick={loadMoreRooms}
+                variant="outline"
+                className="border-[#4ecdc4]/30 text-[#4ecdc4] hover:bg-[#4ecdc4]/10"
+                disabled={loading}
+              >
+                더 많은 시청방 보기
+              </Button>
+            )}
+            
+            {!hasNext && displayRooms.length > 0 && (
+              <p className="text-white/40 text-sm">모든 시청방을 확인했습니다.</p>
+            )}
+          </div>
+        )}
+        </div>
 
         {/* Empty State */}
         {displayRooms.length === 0 && (

--- a/src/components/VideoControls.tsx
+++ b/src/components/VideoControls.tsx
@@ -182,8 +182,8 @@ export function VideoControls({
           )}
         </div>
         <div className="flex items-center justify-between text-sm text-white/80">
-          <span>{formatTime(isDragging ? dragTime : currentTime)}</span>
-          <span>{formatTime(totalDuration)}</span>
+          <span>{formatTime(Math.floor(isDragging ? dragTime : currentTime))}</span>
+          <span>{formatTime(Math.floor(totalDuration))}</span>
         </div>
       </div>
 

--- a/src/components/WatchParty.tsx
+++ b/src/components/WatchParty.tsx
@@ -95,6 +95,7 @@ export function WatchParty({ roomId, onBack, userId, shouldConnect = false, onUs
   const [showHostLeaveConfirm, setShowHostLeaveConfirm] = useState(false) // State for host leave confirmation
 
   // Data State
+  const [preJoinRoomData, setPreJoinRoomData] = useState<WatchRoomDto | null>(null)  // 입장 전 데이터
   const [roomData, setRoomData] = useState<WatchRoomDto | null>(null)
   const [contentData, setContentData] = useState<ContentDto | null>(null)
   const [participants, setParticipants] = useState<Participant[]>([])
@@ -335,6 +336,12 @@ export function WatchParty({ roomId, onBack, userId, shouldConnect = false, onUs
       setLoading(true)
       setError(null)
       try {
+        // 입장 전 시청방 정보 조회
+        console.log('🎬 시청방 정보 조회 시작:', roomId)
+        const preJoinData = await watchRoomService.getWatchRoom(roomId)
+        setPreJoinRoomData(preJoinData)  // API 응답 직접 설정
+        console.log('✅ 입장 전 시청방 정보 조회 완료', { headCount: preJoinData.headCount })
+
         const roomInfo = await watchRoomService.joinWatchRoom(roomId)
         console.log('📋 Room info loaded:', roomInfo)
 
@@ -612,7 +619,7 @@ export function WatchParty({ roomId, onBack, userId, shouldConnect = false, onUs
             <div className="flex items-center justify-center gap-4 text-sm text-white/60 mb-6">
               <div className="flex items-center gap-1">
                 <Users className="w-4 h-4" />
-                <span>{roomData?.headCount || 0}명 시청 중</span>
+                <span>{preJoinRoomData?.headCount || 0}명 시청 중</span>
               </div>
               <span>•</span>
               <div className="flex items-center gap-1">

--- a/src/components/WatchParty.tsx
+++ b/src/components/WatchParty.tsx
@@ -1068,7 +1068,8 @@ export function WatchParty({ roomId, onBack, userId, shouldConnect = false, onUs
             </AlertDialogTitle>
             <AlertDialogDescription className="text-white/70">
               {isHost 
-                ? "방장이 나가면 시청방이 삭제됩니다. 정말로 나가시겠습니까?"
+                ? participants.length>= 2 ? "방장 권한이 양도됩니다. 정말로 나가시겠습니까?"
+                : "방장이 나가면 시청방이 삭제됩니다. 정말로 나가시겠습니까?"
                 : "시청방에서 나가시겠습니까?"
               }
             </AlertDialogDescription>

--- a/src/hooks/useYouTubePlayer.ts
+++ b/src/hooks/useYouTubePlayer.ts
@@ -348,21 +348,20 @@ export function useYouTubePlayer({
 
   
   if (videoSync.action === 'PLAY' || videoSync.isPlaying === true) {
-    // 재생 시 볼륨 제어로 자연스러운 재생 시작
-    playerRef.current.setVolume(0); // 음소거로 재생 시작
+    // 재생 직전 사용자 볼륨 기억
+    const prevVolume = playerRef.current.getVolume();
+    // 자연스러운 재생 시작
+    playerRef.current.setVolume(0); // 음소거로 시작
     playerRef.current.playVideo();
     console.log('▶️ 동기화 재생 시작 (음소거)');
-    
-    // 100ms 후 볼륨 복원
+
+    // 약간의 지연 후 사용자 볼륨으로 복원
     setTimeout(() => {
       if (playerRef.current) {
-        playerRef.current.setVolume(80);
-        console.log('🔊 볼륨 복원');
+        playerRef.current.setVolume(prevVolume);
+        console.log('🔊 볼륨 복원(사용자 설정):', prevVolume);
       }
-    }, 100);
-  } else if (videoSync.action === 'PAUSE') {
-    playerRef.current.pauseVideo();
-    console.log('⏸️ 동기화 일시정지');
+    }, 120);
   }
   
   // Reset flag after a short delay to allow player state to update

--- a/src/services/watchRoomService.ts
+++ b/src/services/watchRoomService.ts
@@ -2,7 +2,7 @@ import {
   WatchRoomDto, 
   WatchRoomCreateRequest, 
   WatchRoomInfoDto, 
-  WatchRoomSearchOptions 
+  CursorPageResponseDto 
 } from '../types/watchRoom'
 
 export class WatchRoomService {
@@ -37,56 +37,34 @@ export class WatchRoomService {
   /**
    * 시청방 목록 조회
    */
-  async getWatchRooms(options?: WatchRoomSearchOptions): Promise<WatchRoomDto[]> {
-    try {
-      const urlParams = new URLSearchParams()
-      
-      if (options?.query) {
-        urlParams.append('searchKeyword', options.query)
-      }
-      
-      if (options?.sortBy) {
-        urlParams.append('sortBy', options.sortBy)
-      }
-      
-      if (options?.limit) {
-        urlParams.append('size', options.limit.toString())
-      }
-      
-      if (options?.offset) {
-        urlParams.append('cursor', options.offset?.toString() || '')
-      }
-      
-      const url = `${this.baseUrl}${urlParams.toString() ? '?' + urlParams.toString() : ''}`
-      
-      const response = await this.authenticatedFetch(url)
-      
-      if (!response.ok) {
-        throw new Error(`시청방 목록 조회에 실패했습니다. Status: ${response.status}`)
-      }
-      
-      const responseData = await response.json()
-      
-      // CursorPageResponseDto 구조에서 data 배열 추출
-      const rooms = responseData.data || responseData
-      
-      // 배열인지 확인
-      if (!Array.isArray(rooms)) {
-        console.error('시청방 데이터가 배열이 아닙니다:', responseData)
-        return []
-      }
-      
-      // 클라이언트 사이드에서 정렬 처리
-      if (options?.sortBy) {
-        return this.sortWatchRooms(rooms, options.sortBy)
-      }
-      
-      return rooms
-    } catch (error) {
-      console.error('시청방 목록 조회 오류:', error)
-      throw error
+/**
+ * 시청방 목록 조회
+ */
+  async getWatchRooms(params: {
+    query?: string
+    sortBy?: string
+    direction?: 'asc' | 'desc'
+    cursor?: string | null
+    size?: number
+  }): Promise<CursorPageResponseDto<WatchRoomDto>> {
+    const url = new URL(this.baseUrl);
+    
+    // URL에 파라미터 추가
+    if (params.query) url.searchParams.append('query', params.query);
+    if (params.sortBy) url.searchParams.append('sortBy', params.sortBy);
+    if (params.direction) url.searchParams.append('direction', params.direction);
+    if (params.cursor) url.searchParams.append('cursor', params.cursor);
+    if (params.size) url.searchParams.append('size', params.size.toString());
+    
+    const response = await this.authenticatedFetch(url.toString());
+    
+    if (!response.ok) {
+      throw new Error(`시청방 목록 조회에 실패했습니다. Status: ${response.status}`);
     }
+    
+    return await response.json();
   }
+
 
   /**
    * 시청방 생성
@@ -171,9 +149,7 @@ export class WatchRoomService {
   /**
    * 시청방 검색
    */
-  async searchWatchRooms(query: string, sortBy: 'createdAt' | 'title' | 'participantCount' = 'participantCount'): Promise<WatchRoomDto[]> {
-    return this.getWatchRooms({ query, sortBy })
-  }
+
 
   /**
    * 시청방 목록 정렬

--- a/src/services/watchRoomService.ts
+++ b/src/services/watchRoomService.ts
@@ -159,7 +159,7 @@ export class WatchRoomService {
         },
         participantsInfoDto: {
           participantDtoList: [],
-          participantCount: 0
+          participantCount: room.headCount  // API의 headCount를 직접 사용
         }
       }
     } catch (error) {

--- a/src/types/watchRoom.ts
+++ b/src/types/watchRoom.ts
@@ -97,6 +97,14 @@ export interface WatchRoomSearchOptions {
   offset?: number
 }
 
+export interface CursorPageResponseDto<T> {
+  data: T[]
+  nextCursor: string | null
+  size: number
+  totalElements: number
+  hasNext: boolean
+}
+
 // 백엔드 WebSocket 응답 타입 (실제 백엔드 구조에 맞춤)
 export interface BackendParticipantDto {
   id: string // UUID (문자열로 받음)

--- a/src/types/watchRoom.ts
+++ b/src/types/watchRoom.ts
@@ -1,6 +1,10 @@
 // 시청방 관련 타입 정의
 import { ContentDto } from './content'
 
+/**
+ * 시청방 입장 전 단일 조회용 DTO
+ * API GET /api/rooms/{roomId} 응답과 직접 매핑
+ */
 export interface WatchRoomDto {
   id: string
   title: string
@@ -8,7 +12,7 @@ export interface WatchRoomDto {
   ownerId: string
   ownerName: string
   createdAt: string
-  headCount: number
+  headCount: number  // API 응답의 headCount 직접 사용
   // 기존 호환성을 위한 필드들
   contentTitle?: string // contentDto.title과 동일
   contentId?: string // contentDto.id와 동일
@@ -20,6 +24,10 @@ export interface WatchRoomCreateRequest {
   title: string
 }
 
+/**
+ * 시청방 입장 후 WebSocket 통신용 DTO  
+ * 실시간 참여자 정보와 비디오 동기화 정보 포함
+ */
 export interface WatchRoomInfoDto {
   id: string
   title: string


### PR DESCRIPTION
# 시청방 목록 무한 스크롤 및 버그 수정

## 🆕 새로운 기능
- **무한 스크롤**: 커서 기반 페이지네이션으로 시청방 목록 자동 로딩
- **정렬 옵션 확장**: 6가지 정렬 (참여자 많은/적은 순, 최신/오래된 순, 제목 오름/내림차순)
- **방장 권한 양도**: 방장 나가기 시 참여자 수에 따른 권한 양도/시청방 삭제 안내

## 🐛 버그 수정
- 비디오 progress bar 시간에 나노초 표시 숨김 (`Math.floor()` 적용)
- 시청방 입장 전 참여자 표시 0으로 되는 문제 수정
- 볼륨 80으로 고정되는 문제 수정 (사용자 설정 볼륨 유지)

## 🔧 기술 개선
- `CursorPageResponseDto<T>` 타입 추가로 페이지네이션 지원
- API 서비스 리팩토링 및 타입 안정성 강화
- 무한 스크롤을 위한 상태 관리 개선

## 📊 변경 통계
**6 commits** • **7 files changed** • **+207 -88 lines**

### 주요 변경 파일
- `LiveRooms.tsx` - 무한 스크롤 및 정렬 기능
- `WatchParty.tsx` - 입장 전 데이터 조회, 권한 양도 로직  
- `watchRoomService.ts` - 페이지네이션 API 지원
- `VideoControls.tsx` - 시간 표시 개선
- `useYouTubePlayer.ts` - 볼륨 유지 로직